### PR TITLE
View `Expenditure` and `Income` entries

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ENTRIES;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.entry.EntryType;
+
+/**
+ * View income/expenditure entries to the application.
+ */
+public class ViewCommand extends Command {
+
+    public static final String COMMAND_WORD = "view";
+
+    public static final String MESSAGE_SUCCESS = "Listed all %s";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": View income/expenditure entries to PennyWise. "
+            + "Parameters: "
+            + PREFIX_TYPE + "TYPE "
+            + "[" + PREFIX_MONTH + "MONTH]\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_TYPE + "e "
+            + PREFIX_MONTH + "09-2022 ";
+    public static final String MESSAGE_INVALID_ENTRY_TYPE = "Entry type is invalid.";
+
+    private static final String ENTRY_EXPENDITURE = "expenditures";
+    private static final String ENTRY_INCOME = "income";
+
+    private final EntryType entryType;
+
+    /**
+     * Creates a ViewCommand to view the specified {@code entryType}
+     */
+    public ViewCommand(EntryType entryType) {
+        requireNonNull(entryType);
+        this.entryType = entryType;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        switch (entryType.getEntryType()) {
+        case EXPENDITURE:
+            System.out.println("[ViewCommand] Show all expenditure");
+            model.updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
+            return new CommandResult(String.format(MESSAGE_SUCCESS, ENTRY_EXPENDITURE));
+        case INCOME:
+            System.out.println("[ViewCommand] Show all income");
+            model.updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
+            return new CommandResult(String.format(MESSAGE_SUCCESS, ENTRY_INCOME));
+        }
+
+        throw new CommandException(MESSAGE_INVALID_ENTRY_TYPE);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -67,6 +68,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ViewCommand.COMMAND_WORD:
+            return new ViewCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,6 +11,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
     public static final Prefix PREFIX_AMOUNT = new Prefix("a/");
     public static final Prefix PREFIX_DATE = new Prefix("da/");
+    public static final Prefix PREFIX_MONTH = new Prefix("mo/");
     public static final Prefix PREFIX_TAG = new Prefix("c/");
     // NOT NEEDED
     public static final Prefix PREFIX_PHONE = new Prefix("p/");

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -12,6 +12,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.entry.Amount;
 import seedu.address.model.entry.Date;
 import seedu.address.model.entry.Description;
+import seedu.address.model.entry.EntryType;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -60,6 +61,15 @@ public class ParserUtil {
             throw new ParseException(Description.MESSAGE_CONSTRAINTS);
         }
         return new Description(trimmedDescription);
+    }
+
+    public static EntryType parseEntryType(String entryType) throws ParseException {
+        requireNonNull(entryType);
+        String trimmedEntryType = entryType.trim();
+        if (!EntryType.isValidEntryType(trimmedEntryType)) {
+            throw new ParseException(EntryType.MESSAGE_CONSTRAINTS);
+        }
+        return new EntryType(trimmedEntryType);
     }
 
     public static Amount parseAmount(String amount) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -1,0 +1,42 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MONTH;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.ViewCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.entry.EntryType;
+
+/**
+ * Parses input arguments and creates a new ViewCommand object
+ */
+public class ViewCommandParser implements Parser<ViewCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ViewCommand
+     * object and returns a ViewCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ViewCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TYPE, PREFIX_MONTH);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_TYPE, PREFIX_MONTH) || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+        }
+
+        EntryType entryType = ParserUtil.parseEntryType(argMultimap.getValue(PREFIX_TYPE).get());
+
+        return new ViewCommand(entryType);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/model/entry/Amount.java
+++ b/src/main/java/seedu/address/model/entry/Amount.java
@@ -7,7 +7,7 @@ public class Amount {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Expense amount should only contain positive numbers, and it should be formatted to accept 2 decimal places";
-    public static final String VALIDATION_REGEX = "^\\s*(?=.*[1-9])\\d*(?:\\.\\d{1,2})?\\s*$";;
+    public static final String VALIDATION_REGEX = "^\\s*(?=.*[1-9])\\d*(?:\\.\\d{1,2})?\\s*$";
     public final String amount;
 
     /**

--- a/src/main/java/seedu/address/model/entry/EntryType.java
+++ b/src/main/java/seedu/address/model/entry/EntryType.java
@@ -1,0 +1,84 @@
+package seedu.address.model.entry;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+public class EntryType {
+    private static final String ENTRY_TYPE_EXPENDITURE = "e";
+    private static final String ENTRY_TYPE_INCOME = "i";
+
+    public static final String MESSAGE_CONSTRAINTS = "Entry type should only be either '"
+            + ENTRY_TYPE_EXPENDITURE
+            + "' for expenditure or '"
+            + ENTRY_TYPE_INCOME
+            + "' for income";
+    public static final String VALIDATION_REGEX = "^\\s*([ei])\\s*$";
+
+    public enum Type {
+        EXPENDITURE() {
+            @Override
+            public String toString() {
+                return ENTRY_TYPE_EXPENDITURE;
+            }
+        },
+        INCOME() {
+            @Override
+            public String toString() {
+                return ENTRY_TYPE_INCOME;
+            }
+        };
+
+        public static Type of(String entryType) {
+            boolean isExpenditureEntry = entryType.equals(ENTRY_TYPE_EXPENDITURE);
+            boolean isIncomeEntry = entryType.equals(ENTRY_TYPE_INCOME);
+
+            assert isExpenditureEntry || isIncomeEntry;
+
+            if (isExpenditureEntry) {
+                return Type.EXPENDITURE;
+            }
+            return Type.INCOME;
+        }
+    };
+
+    private final Type entryType;
+
+    /**
+     * Constructs a {@code EntryType}.
+     *
+     * @param entryType A valid entry type.
+     */
+    public EntryType(String entryType) {
+        requireNonNull(entryType);
+        checkArgument(isValidEntryType(entryType), MESSAGE_CONSTRAINTS);
+        this.entryType = Type.of(entryType);
+    }
+
+    /**
+     * Returns true if a given string is a valid entry type.
+     */
+    public static boolean isValidEntryType(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    public Type getEntryType() {
+        return entryType;
+    }
+
+    @Override
+    public String toString() {
+        return entryType.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof EntryType // instanceof handles nulls
+                && entryType.equals(((EntryType) other).entryType)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return entryType.hashCode();
+    }
+}


### PR DESCRIPTION
* Entries correspond to either an 'Expenditure' or 'Income'
* Support parsing of entry type in 'ParserUtil' to be used in
conjunction with parsing 't/' prefixes in the command

<details>
  <summary>Invalid command format, e.g. `view` or `view t/abc mo/2022-09`</summary>
  
![Screenshot 2022-10-09 at 4 34 02 PM](https://user-images.githubusercontent.com/21200681/194746817-e3569b2a-c308-4419-a09a-2db8bdee99f3.png)

![Screenshot 2022-10-09 at 4 34 25 PM](https://user-images.githubusercontent.com/21200681/194746895-967b1f9d-a6f0-4acc-a10f-c63efea1ef14.png)

</details>

<details>
  <summary>View expenditures, e.g. `view t/e mo/2022-09`</summary>
  
![Screenshot 2022-10-09 at 4 34 11 PM](https://user-images.githubusercontent.com/21200681/194746839-a30341ec-f2a9-40bf-b218-f750a1e2acad.png)

</details>

<details>
  <summary>View income, e.g. `view t/i mo/2022-09`</summary>
  
![Screenshot 2022-10-09 at 4 34 15 PM](https://user-images.githubusercontent.com/21200681/194746880-e13d6b7b-453e-44fa-9bdd-505128cdf62b.png)

</details>
