### PR TITLE
Add support for adding income entries

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -1,12 +1,16 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.entry.Entry;
-import seedu.address.model.entry.Expenditure;
+import seedu.address.model.entry.EntryType;
 
 /**
  * Adds an income/expenditure entry to the application.
@@ -32,24 +36,33 @@ public class AddCommand extends Command {
     public static final String MESSAGE_DUPLICATE_PERSON = "This entry already exists in the address book";
 
     final Entry toAdd;
+    final EntryType entryType;
 
     /**
      * Creates an AddEntryCommand to add the specified {@code Expenditure}
      */
-    public AddCommand(Entry entry) {
+    public AddCommand(Entry entry, EntryType entryType) {
         requireNonNull(entry);
         toAdd = entry;
+        this.entryType = entryType;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasEntry(toAdd)) {
+        if (model.hasExpenditure(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        model.addEntry(toAdd);
+        switch (entryType.getEntryType()) {
+        case EXPENDITURE:
+            model.addExpenditure(toAdd);
+            break;
+        case INCOME:
+            model.addIncome(toAdd);
+            break;
+        }
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -9,7 +9,6 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.entry.Entry;
-import seedu.address.model.person.Person;
 
 /**
  * Deletes a person identified using it's displayed index from the address book.
@@ -41,7 +40,7 @@ public class DeleteCommand extends Command {
         }
 
         Entry entryToDelete = lastShownList.get(targetIndex.getZeroBased());
-        model.deleteEntry(entryToDelete);
+        model.deleteExpenditure(entryToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, entryToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -22,11 +22,6 @@ import seedu.address.model.entry.Amount;
 import seedu.address.model.entry.Date;
 import seedu.address.model.entry.Description;
 import seedu.address.model.entry.Entry;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -80,11 +75,11 @@ public class EditCommand extends Command {
         Entry entryToEdit = lastShownList.get(index.getZeroBased());
         Entry editedEntry = createdEditedEntry(entryToEdit, editEntryDescriptor);
 
-        if (!entryToEdit.isSameEntry(editedEntry) && model.hasEntry(editedEntry)) {
+        if (!entryToEdit.isSameEntry(editedEntry) && model.hasExpenditure(editedEntry)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        model.setEntry(entryToEdit, editedEntry);
+        model.setExpenditure(entryToEdit, editedEntry);
         model.updateFilteredEntryList(Model.PREDICATE_SHOW_ALL_ENTRIES);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedEntry));
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,7 +1,11 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -11,12 +15,9 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.entry.Amount;
 import seedu.address.model.entry.Date;
 import seedu.address.model.entry.Description;
-import seedu.address.model.entry.Entry;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
+import seedu.address.model.entry.EntryType;
+import seedu.address.model.entry.Expenditure;
+import seedu.address.model.entry.Income;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -57,9 +58,17 @@ public class AddCommandParser implements Parser<AddCommand> {
         Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Entry entry = new Entry(description, date, amount, tagList);
 
-        return new AddCommand(entry);
+        EntryType entryType = ParserUtil.parseEntryType(argMultimap.getValue(PREFIX_TYPE).get());
+        switch (entryType.getEntryType()) {
+        case EXPENDITURE:
+            Expenditure expenditure = new Expenditure(description, date, amount, tagList);
+            return new AddCommand(expenditure, entryType);
+        case INCOME:
+            Income income = new Income(description, date, amount, tagList);
+            return new AddCommand(income, entryType);
+        }
+        throw new ParseException(EntryType.MESSAGE_CONSTRAINTS);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -12,6 +12,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.entry.Amount;
 import seedu.address.model.entry.Date;
 import seedu.address.model.entry.Description;
+import seedu.address.model.entry.EntryType;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -60,6 +61,15 @@ public class ParserUtil {
             throw new ParseException(Description.MESSAGE_CONSTRAINTS);
         }
         return new Description(trimmedDescription);
+    }
+
+    public static EntryType parseEntryType(String entryType) throws ParseException {
+        requireNonNull(entryType);
+        String trimmedEntryType = entryType.trim();
+        if (!EntryType.isValidEntryType(trimmedEntryType)) {
+            throw new ParseException(EntryType.MESSAGE_CONSTRAINTS);
+        }
+        return new EntryType(trimmedEntryType);
     }
 
     public static Amount parseAmount(String amount) throws ParseException {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -14,7 +14,9 @@ import seedu.address.model.person.UniqueEntryList;
  */
 public class AddressBook implements ReadOnlyPennyWise {
 
-    private final UniqueEntryList entries;
+    private final UniqueEntryList expenditure;
+
+    private final UniqueEntryList income;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -24,7 +26,8 @@ public class AddressBook implements ReadOnlyPennyWise {
      *   among constructors.
      */
     {
-        entries = new UniqueEntryList();
+        expenditure = new UniqueEntryList();
+        income = new UniqueEntryList();
     }
 
     public AddressBook() {}
@@ -43,8 +46,16 @@ public class AddressBook implements ReadOnlyPennyWise {
      * Replaces the contents of the person list with {@code persons}.
      * {@code persons} must not contain duplicate persons.
      */
-    public void setEntries(List<Entry> entries) {
-        this.entries.setEntries(entries);
+    public void setExpenditure(List<Entry> entries) {
+        this.expenditure.setEntries(entries);
+    }
+
+    /**
+     * Replaces the contents of the person list with {@code persons}.
+     * {@code persons} must not contain duplicate persons.
+     */
+    public void setIncome(List<Entry> entries) {
+        this.income.setEntries(entries);
     }
 
     /**
@@ -53,25 +64,26 @@ public class AddressBook implements ReadOnlyPennyWise {
     public void resetData(ReadOnlyPennyWise newData) {
         requireNonNull(newData);
 
-        setEntries(newData.getEntryList());
+        setExpenditure(newData.getExpenditureList());
+        setIncome(newData.getIncomeList());
     }
 
-    //// person-level operations
+    //// entry-level operations
 
     /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.
      */
-    public boolean hasEntry(Entry entry) {
+    public boolean hasExpenditure(Entry entry) {
         requireNonNull(entry);
-        return entries.contains(entry);
+        return expenditure.contains(entry);
     }
 
     /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */
-    public void addEntry(Entry e) {
-        entries.add(e);
+    public void addExpenditure(Entry e) {
+        expenditure.add(e);
     }
 
     /**
@@ -79,42 +91,83 @@ public class AddressBook implements ReadOnlyPennyWise {
      * {@code target} must exist in the address book.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
-    public void setEntries(Entry target, Entry editedEntry) {
+    public void setExpenditure(Entry target, Entry editedEntry) {
         requireNonNull(editedEntry);
 
-        entries.setEntries(target, editedEntry);
+        expenditure.setEntries(target, editedEntry);
     }
 
     /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
      */
-    public void removeEntry(Entry key) {
-        entries.remove(key);
+    public void removeExpenditure(Entry key) {
+        expenditure.remove(key);
+    }
+
+    /**
+     * Returns true if a person with the same identity as {@code person} exists in the address book.
+     */
+    public boolean hasIncome(Entry entry) {
+        requireNonNull(entry);
+        return income.contains(entry);
+    }
+
+    /**
+     * Adds a person to the address book.
+     * The person must not already exist in the address book.
+     */
+    public void addIncome(Entry e) {
+        income.add(e);
+    }
+
+    /**
+     * Replaces the given person {@code target} in the list with {@code editedPerson}.
+     * {@code target} must exist in the address book.
+     * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
+     */
+    public void setIncome(Entry target, Entry editedEntry) {
+        requireNonNull(editedEntry);
+
+        income.setEntries(target, editedEntry);
+    }
+
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeIncome(Entry key) {
+        income.remove(key);
     }
 
     //// util methods
 
     @Override
     public String toString() {
-        return entries.asUnmodifiableObservableList().size() + " entries";
+        return expenditure.asUnmodifiableObservableList().size() + " entries";
         // TODO: refine later
     }
 
     @Override
-    public ObservableList<Entry> getEntryList() {
-        return entries.asUnmodifiableObservableList();
+    public ObservableList<Entry> getExpenditureList() {
+        return expenditure.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public ObservableList<Entry> getIncomeList() {
+        return income.asUnmodifiableObservableList();
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AddressBook // instanceof handles nulls
-                && entries.equals(((AddressBook) other).entries));
+                && expenditure.equals(((AddressBook) other).expenditure)
+                && income.equals(((AddressBook) other).income));
     }
 
     @Override
     public int hashCode() {
-        return entries.hashCode();
+        return expenditure.hashCode();
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,7 +5,6 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.person.Person;
 import seedu.address.model.entry.Entry;
 
 /**
@@ -56,26 +55,50 @@ public interface Model {
     /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.
      */
-    boolean hasEntry(Entry entry);
+    boolean hasExpenditure(Entry entry);
 
     /**
      * Deletes the given person.
      * The person must exist in the address book.
      */
-    void deleteEntry(Entry target);
+    void deleteExpenditure(Entry target);
 
     /**
      * Adds the given person.
      * {@code person} must not already exist in the address book.
      */
-    void addEntry(Entry entry);
+    void addExpenditure(Entry entry);
 
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
      * {@code target} must exist in the address book.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
-    void setEntry(Entry target, Entry editedEntry);
+    void setExpenditure(Entry target, Entry editedEntry);
+
+    /**
+     * Returns true if a person with the same identity as {@code person} exists in the address book.
+     */
+    boolean hasIncome(Entry entry);
+
+    /**
+     * Deletes the given person.
+     * The person must exist in the address book.
+     */
+    void deleteIncome(Entry target);
+
+    /**
+     * Adds the given person.
+     * {@code person} must not already exist in the address book.
+     */
+    void addIncome(Entry entry);
+
+    /**
+     * Replaces the given person {@code target} with {@code editedPerson}.
+     * {@code target} must exist in the address book.
+     * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
+     */
+    void setIncome(Entry target, Entry editedEntry);
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Entry> getFilteredEntryList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -21,7 +21,8 @@ public class ModelManager implements Model {
 
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
-    private final FilteredList<Entry> filteredEntries;
+    private final FilteredList<Entry> filteredExpenditure;
+    private final FilteredList<Entry> filteredIncome;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -33,7 +34,8 @@ public class ModelManager implements Model {
 
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
-        filteredEntries = new FilteredList<>(this.addressBook.getEntryList());
+        filteredExpenditure = new FilteredList<>(this.addressBook.getExpenditureList());
+        filteredIncome = new FilteredList<>(this.addressBook.getIncomeList());
     }
 
     public ModelManager() {
@@ -88,27 +90,51 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean hasEntry(Entry entry) {
+    public boolean hasExpenditure(Entry entry) {
         requireNonNull(entry);
-        return addressBook.hasEntry(entry);
+        return addressBook.hasExpenditure(entry);
     }
 
     @Override
-    public void deleteEntry(Entry target) {
-        addressBook.removeEntry(target);
+    public void deleteExpenditure(Entry target) {
+        addressBook.removeExpenditure(target);
     }
 
     @Override
-    public void addEntry(Entry entry) {
-        addressBook.addEntry(entry);
+    public void addExpenditure(Entry entry) {
+        addressBook.addExpenditure(entry);
         updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
     }
 
     @Override
-    public void setEntry(Entry target, Entry editedEntry) {
+    public void setExpenditure(Entry target, Entry editedEntry) {
         requireAllNonNull(target, editedEntry);
 
-        addressBook.setEntries(target, editedEntry);
+        addressBook.setExpenditure(target, editedEntry);
+    }
+
+    @Override
+    public boolean hasIncome(Entry entry) {
+        requireNonNull(entry);
+        return addressBook.hasIncome(entry);
+    }
+
+    @Override
+    public void deleteIncome(Entry target) {
+        addressBook.removeIncome(target);
+    }
+
+    @Override
+    public void addIncome(Entry entry) {
+        addressBook.addIncome(entry);
+        updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
+    }
+
+    @Override
+    public void setIncome(Entry target, Entry editedEntry) {
+        requireAllNonNull(target, editedEntry);
+
+        addressBook.setIncome(target, editedEntry);
     }
 
     //=========== Filtered Person List Accessors =============================================================
@@ -119,12 +145,12 @@ public class ModelManager implements Model {
      */
     @Override
     public ObservableList<Entry> getFilteredEntryList() {
-        return filteredEntries;
+        return filteredExpenditure;
     }
 
     public void updateFilteredEntryList(Predicate<Entry> predicate) {
         requireNonNull(predicate);
-        filteredEntries.setPredicate(predicate);
+        filteredExpenditure.setPredicate(predicate);
     }
 
     @Override
@@ -143,7 +169,7 @@ public class ModelManager implements Model {
         ModelManager other = (ModelManager) obj;
         return addressBook.equals(other.addressBook)
                 && userPrefs.equals(other.userPrefs)
-                && filteredEntries.equals(other.filteredEntries);
+                && filteredExpenditure.equals(other.filteredExpenditure);
     }
 
 }

--- a/src/main/java/seedu/address/model/ReadOnlyPennyWise.java
+++ b/src/main/java/seedu/address/model/ReadOnlyPennyWise.java
@@ -2,7 +2,6 @@ package seedu.address.model;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.entry.Entry;
-import seedu.address.model.person.Person;
 
 /**
  * Unmodifiable view of an address book
@@ -10,9 +9,15 @@ import seedu.address.model.person.Person;
 public interface ReadOnlyPennyWise {
 
     /**
-     * Returns an unmodifiable view of the persons list.
-     * This list will not contain any duplicate persons.
+     * Returns an unmodifiable view of the expenditure list.
+     * This list will not contain any duplicate expenditure.
      */
-    ObservableList<Entry> getEntryList();
+    ObservableList<Entry> getExpenditureList();
+
+    /**
+     * Returns an unmodifiable view of the income list.
+     * This list will not contain any duplicate income.
+     */
+    ObservableList<Entry> getIncomeList();
 
 }

--- a/src/main/java/seedu/address/model/entry/EntryType.java
+++ b/src/main/java/seedu/address/model/entry/EntryType.java
@@ -1,0 +1,84 @@
+package seedu.address.model.entry;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+public class EntryType {
+    private static final String ENTRY_TYPE_EXPENDITURE = "e";
+    private static final String ENTRY_TYPE_INCOME = "i";
+
+    public static final String MESSAGE_CONSTRAINTS = "Entry type should only be either '"
+            + ENTRY_TYPE_EXPENDITURE
+            + "' for expenditure or '"
+            + ENTRY_TYPE_INCOME
+            + "' for income";
+    public static final String VALIDATION_REGEX = "^\\s*([ei])\\s*$";
+
+    public enum Type {
+        EXPENDITURE() {
+            @Override
+            public String toString() {
+                return ENTRY_TYPE_EXPENDITURE;
+            }
+        },
+        INCOME() {
+            @Override
+            public String toString() {
+                return ENTRY_TYPE_INCOME;
+            }
+        };
+
+        public static Type of(String entryType) {
+            boolean isExpenditureEntry = entryType.equals(ENTRY_TYPE_EXPENDITURE);
+            boolean isIncomeEntry = entryType.equals(ENTRY_TYPE_INCOME);
+
+            assert isExpenditureEntry || isIncomeEntry;
+
+            if (isExpenditureEntry) {
+                return Type.EXPENDITURE;
+            }
+            return Type.INCOME;
+        }
+    };
+
+    private final Type entryType;
+
+    /**
+     * Constructs a {@code EntryType}.
+     *
+     * @param entryType A valid entry type.
+     */
+    public EntryType(String entryType) {
+        requireNonNull(entryType);
+        checkArgument(isValidEntryType(entryType), MESSAGE_CONSTRAINTS);
+        this.entryType = Type.of(entryType);
+    }
+
+    /**
+     * Returns true if a given string is a valid entry type.
+     */
+    public static boolean isValidEntryType(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    public Type getEntryType() {
+        return entryType;
+    }
+
+    @Override
+    public String toString() {
+        return entryType.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof EntryType // instanceof handles nulls
+                && entryType.equals(((EntryType) other).entryType)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return entryType.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/entry/Income.java
+++ b/src/main/java/seedu/address/model/entry/Income.java
@@ -1,0 +1,34 @@
+package seedu.address.model.entry;
+
+import java.util.Set;
+
+import seedu.address.model.tag.Tag;
+
+/**
+ * Represents an income entry.
+ */
+public class Income extends Entry {
+    /**
+     * Every field must be present and not null.
+     */
+    public Income(Description description, Date date, Amount amount, Set<Tag> tags) {
+        super(description, date, amount, tags);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(getDescription())
+                .append("; Date: ")
+                .append(getDate())
+                .append("; Amount: ")
+                .append(getAmount());
+
+        Set<Tag> tags = getTags();
+        if (!tags.isEmpty()) {
+            builder.append("; Tags: ");
+            tags.forEach(builder::append);
+        }
+        return builder.toString();
+    }
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -28,7 +28,7 @@ public class SampleDataUtil {
     public static ReadOnlyPennyWise getSampleAddressBook() {
         AddressBook sampleAb = new AddressBook();
         for (Entry sampleEntry : getSampleEntries()) {
-            sampleAb.addEntry(sampleEntry);
+            sampleAb.addExpenditure(sampleEntry);
         }
         return sampleAb;
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedEntry.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedEntry.java
@@ -1,37 +1,37 @@
 package seedu.address.storage;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.entry.Amount;
-import seedu.address.model.entry.Date;
-import seedu.address.model.entry.Description;
-import seedu.address.model.entry.Entry;
-import seedu.address.model.person.*;
-import seedu.address.model.tag.Tag;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.entry.Amount;
+import seedu.address.model.entry.Date;
+import seedu.address.model.entry.Description;
+import seedu.address.model.entry.Entry;
+import seedu.address.model.tag.Tag;
+
 /**
  * Jackson-friendly version of {@link Entry}.
  */
 public class JsonAdaptedEntry {
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
-    private final String description;
-    private final String amount;
-    private final String date;
-    private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+    protected final String description;
+    protected final String amount;
+    protected final String date;
+    protected final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedEntry} with the given person details.
      */
     @JsonCreator
     public JsonAdaptedEntry(@JsonProperty("description") String description, @JsonProperty("amount") String amount,
-                             @JsonProperty("date") String date, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+                            @JsonProperty("date") String date, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.description = description;
         this.amount = amount;
         this.date = date;
@@ -52,41 +52,41 @@ public class JsonAdaptedEntry {
                 .collect(Collectors.toList()));
     }
 
-    /**
-     * Converts this Jackson-friendly adapted person object into the model's {@code Entry} object.
-     *
-     * @throws IllegalValueException if there were any data constraints violated in the adapted entry.
-     */
-    public Entry toModelType() throws IllegalValueException {
-        final List<Tag> personTags = new ArrayList<>();
-        for (JsonAdaptedTag tag : tagged) {
-            personTags.add(tag.toModelType());
-        }
-
+    public void checkIsValidJsonEntry() throws IllegalValueException {
         if (description == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName()));
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName()));
         }
         if (!Description.isValidDescription(description)) {
-            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+            throw new IllegalValueException(Description.MESSAGE_CONSTRAINTS);
         }
-        final Description modelDescription = new Description(description);
-
         if (amount == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Amount.class.getSimpleName()));
         }
         if (!Amount.isValidAmount(amount)) {
             throw new IllegalValueException(Amount.MESSAGE_CONSTRAINTS);
         }
-        final Amount modelAmount = new Amount(amount);
-
         if (date == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName()));
         }
-        if (!Date.isValidDate(date  )) {
-            throw new IllegalValueException(Email.MESSAGE_CONSTRAINTS);
+        if (!Date.isValidDate(date)) {
+            throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
         }
+    }
+    /**
+     * Converts this Jackson-friendly adapted person object into the model's {@code Entry} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted entry.
+     */
+    public Entry toModelType() throws IllegalValueException {
+        checkIsValidJsonEntry();
+        final List<Tag> personTags = new ArrayList<>();
+        for (JsonAdaptedTag tag : tagged) {
+            personTags.add(tag.toModelType());
+        }
+        final Description modelDescription = new Description(description);
+        final Amount modelAmount = new Amount(amount);
         final Date modelDate = new Date(date);
-
         final Set<Tag> modelTags = new HashSet<>(personTags);
         return new Entry(modelDescription, modelDate, modelAmount, modelTags);
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedExpenditure.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedExpenditure.java
@@ -1,0 +1,44 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.entry.*;
+import seedu.address.model.tag.Tag;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Jackson-friendly version of {@link Expenditure}.
+ */
+public class JsonAdaptedExpenditure extends JsonAdaptedEntry {
+    /**
+     * Constructs a {@code JsonAdaptedEntry} with the given person details.
+     */
+    @JsonCreator
+    public JsonAdaptedExpenditure(@JsonProperty("description") String description, @JsonProperty("amount") String amount,
+                            @JsonProperty("date") String date, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+        super(description, amount, date, tagged);
+    }
+
+    public JsonAdaptedExpenditure(Entry source) {
+        super(source);
+    }
+
+    @Override
+    public Expenditure toModelType() throws IllegalValueException {
+        checkIsValidJsonEntry();
+        final List<Tag> personTags = new ArrayList<>();
+        for (JsonAdaptedTag tag : tagged) {
+            personTags.add(tag.toModelType());
+        }
+        final Description modelDescription = new Description(description);
+        final Amount modelAmount = new Amount(amount);
+        final Date modelDate = new Date(date);
+        final Set<Tag> modelTags = new HashSet<>(personTags);
+        return new Expenditure(modelDescription, modelDate, modelAmount, modelTags);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedIncome.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedIncome.java
@@ -1,0 +1,48 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.entry.*;
+import seedu.address.model.tag.Tag;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Jackson-friendly version of {@link Income}
+ */
+public class JsonAdaptedIncome extends JsonAdaptedEntry {
+    /**
+     * Constructs a {@code JsonAdaptedEntry} with the given person details.
+     */
+    @JsonCreator
+    public JsonAdaptedIncome(@JsonProperty("description") String description, @JsonProperty("amount") String amount,
+                            @JsonProperty("date") String date, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+        super(description, amount, date, tagged);
+    }
+
+    public JsonAdaptedIncome(Entry source) {
+        super(source);
+    }
+
+    @Override
+    public Income toModelType() throws IllegalValueException {
+        checkIsValidJsonEntry();
+        final List<Tag> personTags = new ArrayList<>();
+        for (JsonAdaptedTag tag : tagged) {
+            personTags.add(tag.toModelType());
+        }
+
+        final Description modelDescription = new Description(description);
+
+        final Amount modelAmount = new Amount(amount);
+
+        final Date modelDate = new Date(date);
+
+        final Set<Tag> modelTags = new HashSet<>(personTags);
+        return new Income(modelDescription, modelDate, modelAmount, modelTags);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -21,14 +21,17 @@ class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
 
-    private final List<JsonAdaptedEntry> entries = new ArrayList<>();
+    private final List<JsonAdaptedExpenditure> expenditures = new ArrayList<>();
+    private final List<JsonAdaptedIncome> incomes = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableAddressBook} with the given persons.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("entries") List<JsonAdaptedEntry> entries) {
-        this.entries.addAll(entries);
+    public JsonSerializableAddressBook(@JsonProperty("expenditures") List<JsonAdaptedExpenditure> expenditures,
+                                       @JsonProperty("incomes") List<JsonAdaptedIncome> incomes) {
+        this.expenditures.addAll(expenditures);
+        this.incomes.addAll(incomes);
     }
 
     /**
@@ -37,7 +40,9 @@ class JsonSerializableAddressBook {
      * @param source future changes to this will not affect the created {@code JsonSerializableAddressBook}.
      */
     public JsonSerializableAddressBook(ReadOnlyPennyWise source) {
-        entries.addAll(source.getExpenditureList().stream().map(JsonAdaptedEntry::new).collect(Collectors.toList()));
+        expenditures.addAll(
+                source.getExpenditureList().stream().map(JsonAdaptedExpenditure::new).collect(Collectors.toList()));
+        incomes.addAll(source.getIncomeList().stream().map(JsonAdaptedIncome::new).collect(Collectors.toList()));
     }
 
     /**
@@ -47,12 +52,19 @@ class JsonSerializableAddressBook {
      */
     public AddressBook toModelType() throws IllegalValueException {
         AddressBook addressBook = new AddressBook();
-        for (JsonAdaptedEntry jsonAdaptedEntry : entries) {
-            Entry e = jsonAdaptedEntry.toModelType();
+        for (JsonAdaptedExpenditure jsonAdaptedExpenditure : expenditures) {
+            Entry e = jsonAdaptedExpenditure.toModelType();
             if (addressBook.hasExpenditure(e)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
-            addressBook.hasExpenditure(e);
+            addressBook.addExpenditure(e);
+        }
+        for (JsonAdaptedIncome jsonAdaptedIncome : incomes) {
+            Entry e = jsonAdaptedIncome.toModelType();
+            if (addressBook.hasIncome(e)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
+            }
+            addressBook.addIncome(e);
         }
         return addressBook;
     }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -12,7 +12,6 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyPennyWise;
 import seedu.address.model.entry.Entry;
-import seedu.address.model.person.Person;
 
 /**
  * An Immutable AddressBook that is serializable to JSON format.
@@ -38,7 +37,7 @@ class JsonSerializableAddressBook {
      * @param source future changes to this will not affect the created {@code JsonSerializableAddressBook}.
      */
     public JsonSerializableAddressBook(ReadOnlyPennyWise source) {
-        entries.addAll(source.getEntryList().stream().map(JsonAdaptedEntry::new).collect(Collectors.toList()));
+        entries.addAll(source.getExpenditureList().stream().map(JsonAdaptedEntry::new).collect(Collectors.toList()));
     }
 
     /**
@@ -50,11 +49,10 @@ class JsonSerializableAddressBook {
         AddressBook addressBook = new AddressBook();
         for (JsonAdaptedEntry jsonAdaptedEntry : entries) {
             Entry e = jsonAdaptedEntry.toModelType();
-            if (addressBook.hasEntry(e)) {
+            if (addressBook.hasExpenditure(e)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
-            addressBook.hasEntry(e);
-            addressBook.addEntry(e);
+            addressBook.hasExpenditure(e);
         }
         return addressBook;
     }


### PR DESCRIPTION
## Changes

- Added `EntryType` and `parseEntryType()` in `ParserUtil` according to Emily's [PR](https://github.com/AY2223S1-CS2103T-W17-2/tp/pull/33!)
- Added `Income` class
- Modified `AddCommand` and `AddCommandParser` to add `Expenditure` / `Income` object according to the type param
- Change entry list into expenditure list and income list in `AddressBook`
- Change filtered list into filtered expenditure list and filtered income list in `ModelManager`
### Storage
Changed the json save format into:
```
{
  "expenditures" : [ {
    "description" : "LunchA",
    "amount" : "20",
    "date" : "20-01-2022",
    "tagged" : [ "Lunch" ]
  },
  {
    "description" : "LunchB",
    "amount" : "20",
    "date" : "20-01-2022",
    "tagged" : [ "Lunch" ]
  } ],
  "incomes" : [ {
    "description" : "TA",
    "amount" : "30",
    "date" : "20-02-2022",
    "tagged" : [ "part-time" ]
  } ]
}
```

### TODO
- [x] Update storage
- [ ] Update delete command
- [ ] Update tests