### PR TITLE
Fix `Edit` command and tests

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -88,16 +88,18 @@ public class EditCommand extends Command {
         Entry entryToEdit = lastShownList.get(index.getZeroBased());
         Entry editedEntry = createdEditedEntry(entryToEdit, editEntryDescriptor);
 
-        if (!entryToEdit.isSameEntry(editedEntry) && model.hasExpenditure(editedEntry)) {
-            throw new CommandException(MESSAGE_DUPLICATE_ENTRY);
-        }
-
         switch (entryType.getEntryType()) {
         case EXPENDITURE:
+            if (!entryToEdit.isSameEntry(editedEntry) && model.hasExpenditure(editedEntry)) {
+                throw new CommandException(MESSAGE_DUPLICATE_ENTRY);
+            }
             model.setExpenditure(entryToEdit, editedEntry);
             model.updateFilteredExpenditureList(Model.PREDICATE_SHOW_ALL_ENTRIES);
             break;
         case INCOME:
+            if (!entryToEdit.isSameEntry(editedEntry) && model.hasIncome(editedEntry)) {
+                throw new CommandException(MESSAGE_DUPLICATE_ENTRY);
+            }
             model.setIncome(entryToEdit, editedEntry);
             model.updateFilteredIncomeList(Model.PREDICATE_SHOW_ALL_ENTRIES);
             break;

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TYPE_EXPENDITURE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TYPE_INCOME;
@@ -8,8 +9,8 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showExpenditureAtIndex;
 import static seedu.address.testutil.TypicalEntry.getTypicalPennyWise;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ENTRY;
 
 import org.junit.jupiter.api.Test;
 
@@ -33,8 +34,8 @@ public class DeleteCommandTest {
     // need income version
     @Test
     public void execute_validIndexUnfilteredExpenditureList_success() {
-        Entry expenditureToDelete = model.getFilteredExpenditureList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON, this.expenditureType);
+        Entry expenditureToDelete = model.getFilteredExpenditureList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ENTRY, this.expenditureType);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, expenditureToDelete);
 
@@ -54,10 +55,10 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexFilteredExpenditureList_success() {
-        showExpenditureAtIndex(model, INDEX_FIRST_PERSON);
+        showExpenditureAtIndex(model, INDEX_FIRST_ENTRY);
 
-        Entry expenditureToDelete = model.getFilteredExpenditureList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON, this.expenditureType);
+        Entry expenditureToDelete = model.getFilteredExpenditureList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_ENTRY, this.expenditureType);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, expenditureToDelete);
 
@@ -70,9 +71,9 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexFilteredExpenditureList_throwsCommandException() {
-        showExpenditureAtIndex(model, INDEX_FIRST_PERSON);
+        showExpenditureAtIndex(model, INDEX_FIRST_ENTRY);
 
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        Index outOfBoundIndex = INDEX_SECOND_ENTRY;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getPennyWise().getExpenditureList().size());
 
@@ -83,24 +84,24 @@ public class DeleteCommandTest {
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON, expenditureType);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON, expenditureType);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_ENTRY, expenditureType);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_ENTRY, expenditureType);
 
         // same object -> returns true
-        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+        assertEquals(deleteFirstCommand, deleteFirstCommand);
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON, expenditureType);
-        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_ENTRY, expenditureType);
+        assertEquals(deleteFirstCommand, deleteFirstCommandCopy);
 
         // different types -> returns false
-        assertFalse(deleteFirstCommand.equals(1));
+        assertNotEquals(1, deleteFirstCommand);
 
         // null -> returns false
-        assertFalse(deleteFirstCommand.equals(null));
+        assertNotEquals(null, deleteFirstCommand);
 
         // different person -> returns false
-        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+        assertNotEquals(deleteFirstCommand, deleteSecondCommand);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -1,10 +1,12 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DINNER;
 import static seedu.address.logic.commands.CommandTestUtil.LUNCH;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AMT_TUITION;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DATE_TUITION;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DESC_TUITION;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_PERSONAL;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TYPE_EXPENDITURE;
@@ -12,9 +14,10 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showExpenditureAtIndex;
 import static seedu.address.testutil.TypicalEntry.getTypicalPennyWise;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ENTRY;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
@@ -34,18 +37,40 @@ import seedu.address.testutil.ExpenditureBuilder;
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(getTypicalPennyWise(), new UserPrefs());
+    private Model model;
+
+    @BeforeEach
+    public void setModel() {
+        model = new ModelManager(getTypicalPennyWise(), new UserPrefs());
+    }
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Entry editedEntry = new ExpenditureBuilder().withDescription("Acai").build();
-        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder(editedEntry, new EntryType("e")).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+        Index indexLastEntry = Index.fromOneBased(model.getFilteredExpenditureList().size());
+        Entry lastEntry = model.getFilteredExpenditureList().get(indexLastEntry.getZeroBased());
+
+        ExpenditureBuilder expenditureInList = new ExpenditureBuilder(lastEntry);
+
+        Entry editedEntry = expenditureInList
+                .withDescription(VALID_DESC_TUITION)
+                .withAmount(VALID_AMT_TUITION)
+                .withTag(VALID_TAG_PERSONAL)
+                .withDate(VALID_DATE_TUITION)
+                .build();
+        // Specify all fields to be edited
+        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder()
+                .withType(VALID_TYPE_EXPENDITURE)
+                .withDescription(VALID_DESC_TUITION)
+                .withAmount(VALID_AMT_TUITION)
+                .withTag(VALID_TAG_PERSONAL)
+                .withDate(VALID_DATE_TUITION)
+                .build();
+        EditCommand editCommand = new EditCommand(indexLastEntry, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry);
 
         Model expectedModel = new ModelManager(new PennyWise(model.getPennyWise()), new UserPrefs());
-        expectedModel.setExpenditure(model.getFilteredExpenditureList().get(0), editedEntry);
+        expectedModel.setExpenditure(lastEntry, editedEntry);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -56,11 +81,19 @@ public class EditCommandTest {
         Entry lastEntry = model.getFilteredExpenditureList().get(indexLastEntry.getZeroBased());
 
         ExpenditureBuilder expenditureInList = new ExpenditureBuilder(lastEntry);
-        Entry editedEntry = expenditureInList.withDescription(VALID_DESC_TUITION)
-                .withAmount(VALID_AMT_TUITION).withTag(VALID_TAG_PERSONAL).build();
 
-        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder().withType(VALID_TYPE_EXPENDITURE)
-                .withDescription(VALID_DESC_TUITION).withAmount(VALID_AMT_TUITION).withTag(VALID_TAG_PERSONAL).build();
+        Entry editedEntry = expenditureInList
+                .withDescription(VALID_DESC_TUITION)
+                .withAmount(VALID_AMT_TUITION)
+                .build();
+
+        // Specify only the description and amount field to be updated
+        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder()
+                .withType(VALID_TYPE_EXPENDITURE)
+                .withDescription(VALID_DESC_TUITION)
+                .withAmount(VALID_AMT_TUITION)
+                .build();
+
         EditCommand editCommand = new EditCommand(indexLastEntry, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry);
@@ -73,11 +106,11 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditEntryDescriptor descriptor = new EditEntryDescriptor();
-        descriptor.setTag(null);
-        descriptor.setType(new EntryType("e"));
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
-        Entry editedEntry = model.getFilteredExpenditureList().get(INDEX_FIRST_PERSON.getZeroBased());
+        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder()
+                .withType(EntryType.ENTRY_TYPE_EXPENDITURE)
+                .build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_ENTRY, descriptor);
+        Entry editedEntry = model.getFilteredExpenditureList().get(INDEX_FIRST_ENTRY.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry);
 
@@ -88,96 +121,115 @@ public class EditCommandTest {
 
     @Test
     public void execute_filteredList_success() {
-        showExpenditureAtIndex(model, INDEX_FIRST_PERSON);
+        showExpenditureAtIndex(model, INDEX_FIRST_ENTRY);
 
-        Entry entryInFilteredList = model.getFilteredExpenditureList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Entry entryInFilteredList = model.getFilteredExpenditureList().get(INDEX_FIRST_ENTRY.getZeroBased());
         Entry editedEntry = new ExpenditureBuilder(entryInFilteredList)
-                .withDescription(VALID_DESC_TUITION).withTag(VALID_TAG_PERSONAL).build();
+                .withDescription(VALID_DESC_TUITION)
+                .withTag(VALID_TAG_PERSONAL)
+                .build();
 
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditEntryDescriptorBuilder().withType(VALID_TYPE_EXPENDITURE)
-                        .withDescription(VALID_DESC_TUITION).withTag(VALID_TAG_PERSONAL).build());
+        EditCommand editCommand = new EditCommand(
+                INDEX_FIRST_ENTRY,
+                new EditEntryDescriptorBuilder()
+                        .withType(VALID_TYPE_EXPENDITURE)
+                        .withDescription(VALID_DESC_TUITION)
+                        .withTag(VALID_TAG_PERSONAL)
+                        .build()
+        );
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry);
 
         Model expectedModel = new ModelManager(new PennyWise(model.getPennyWise()), new UserPrefs());
-        expectedModel.setExpenditure(model.getFilteredExpenditureList().get(0), editedEntry);
+        expectedModel.setExpenditure(
+                model.getFilteredExpenditureList().get(INDEX_FIRST_ENTRY.getZeroBased()),
+                editedEntry
+        );
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
-    public void execute_duplicatePersonUnfilteredList_failure() {
-        Entry firstEntry = model.getFilteredExpenditureList().get(INDEX_FIRST_PERSON.getZeroBased());
-        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder(firstEntry, new EntryType("e")).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
+    public void execute_duplicateEntryUnfilteredList_failure() {
+        Entry firstEntry = model.getFilteredExpenditureList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder(
+                firstEntry, new EntryType(EntryType.ENTRY_TYPE_EXPENDITURE)
+        ).build();
+        EditCommand editCommand = new EditCommand(INDEX_SECOND_ENTRY, descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_ENTRY);
     }
 
     @Test
-    public void execute_duplicatePersonFilteredList_failure() {
-        showExpenditureAtIndex(model, INDEX_FIRST_PERSON);
+    public void execute_duplicateEntryFilteredList_failure() {
+        showExpenditureAtIndex(model, INDEX_FIRST_ENTRY);
 
-        // edit person in filtered list into a duplicate in address book
-        Entry entryInList = model.getPennyWise().getExpenditureList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditEntryDescriptorBuilder(entryInList, new EntryType("e")).build());
+        // Edit entry in filtered list (i.e. the 1st entry in the entire list) into a duplicate
+        // (i.e. the 2nd entry in the entire list) in PennyWise.
+        Entry entryInList = model.getPennyWise().getExpenditureList().get(INDEX_SECOND_ENTRY.getZeroBased());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_ENTRY,
+                new EditEntryDescriptorBuilder(entryInList, new EntryType(EntryType.ENTRY_TYPE_EXPENDITURE)).build()
+        );
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_ENTRY);
     }
 
     @Test
-    public void execute_invalidPersonIndexUnfilteredList_failure() {
+    public void execute_invalidEntryIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredExpenditureList().size() + 1);
-        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder().withType(VALID_TYPE_EXPENDITURE)
-                .withDescription(VALID_DESC_TUITION).build();
+        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder()
+                .withType(VALID_TYPE_EXPENDITURE)
+                .withDescription(VALID_DESC_TUITION)
+                .build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
     }
 
     /**
-     * Edit filtered list where index is larger than size of filtered list,
-     * but smaller than size of address book
+     * Edit filtered list where index is larger than size of filtered list, but smaller than size of PennyWise.
      */
     @Test
-    public void execute_invalidPersonIndexFilteredList_failure() {
-        showExpenditureAtIndex(model, INDEX_FIRST_PERSON);
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
-        // ensures that outOfBoundIndex is still in bounds of address book list
+    public void execute_invalidEntryIndexFilteredList_failure() {
+        showExpenditureAtIndex(model, INDEX_FIRST_ENTRY);
+        Index outOfBoundIndex = INDEX_SECOND_ENTRY;
+        // ensures that outOfBoundIndex is still in bounds of PennyWise list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getPennyWise().getExpenditureList().size());
 
-        EditCommand editCommand = new EditCommand(outOfBoundIndex,
-                new EditEntryDescriptorBuilder().withType(VALID_TYPE_EXPENDITURE)
-                        .withDescription(VALID_DESC_TUITION).build());
+        EditCommand editCommand = new EditCommand(
+                outOfBoundIndex,
+                new EditEntryDescriptorBuilder()
+                        .withType(VALID_TYPE_EXPENDITURE)
+                        .withDescription(VALID_DESC_TUITION)
+                        .build()
+        );
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, LUNCH);
+        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_ENTRY, LUNCH);
 
         // same values -> returns true
         EditEntryDescriptor copyDescriptor = new EditEntryDescriptor(LUNCH);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
-        assertTrue(standardCommand.equals(commandWithSameValues));
+        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_ENTRY, copyDescriptor);
+        assertEquals(standardCommand, commandWithSameValues);
 
         // same object -> returns true
-        assertTrue(standardCommand.equals(standardCommand));
+        assertEquals(standardCommand, standardCommand);
 
         // null -> returns false
-        assertFalse(standardCommand.equals(null));
+        assertNotEquals(null, standardCommand);
 
         // different types -> returns false
-        assertFalse(standardCommand.equals(new ClearCommand()));
+        assertNotEquals(standardCommand, new ClearCommand());
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, LUNCH)));
+        assertNotEquals(standardCommand, new EditCommand(INDEX_SECOND_ENTRY, LUNCH));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DINNER)));
+        assertNotEquals(standardCommand, new EditCommand(INDEX_FIRST_ENTRY, DINNER));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -6,7 +6,7 @@ import static seedu.address.logic.commands.CommandTestUtil.TYPE_EXPENDITURE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TYPE_EXPENDITURE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +28,7 @@ public class DeleteCommandParserTest {
     public void parse_validArgs_returnsDeleteCommand() {
         EntryType expenditureType = new EntryType(VALID_TYPE_EXPENDITURE);
         String validUserInput = "1" + TYPE_EXPENDITURE;
-        assertParseSuccess(parser, validUserInput, new DeleteCommand(INDEX_FIRST_PERSON, expenditureType));
+        assertParseSuccess(parser, validUserInput, new DeleteCommand(INDEX_FIRST_ENTRY, expenditureType));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -30,9 +30,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TYPE_EXPENDITUR
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_ENTRY;
 
 import org.junit.jupiter.api.Test;
 
@@ -117,7 +117,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_allFieldsSpecified_success() {
-        Index targetIndex = INDEX_SECOND_PERSON;
+        Index targetIndex = INDEX_SECOND_ENTRY;
         String userInput = targetIndex.getOneBased() + TYPE_EXPENDITURE + TAG_DESC_MEAL
                 + AMT_LUNCH + DATE_LUNCH + DESC_LUNCH + TAG_DESC_MEAL;
 
@@ -131,7 +131,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_someFieldsSpecified_success() {
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST_ENTRY;
         String userInput = targetIndex.getOneBased() + TYPE_EXPENDITURE + DESC_LUNCH + AMT_LUNCH + TAG_LUNCH;
 
         EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder().withType(VALID_TYPE_EXPENDITURE)
@@ -144,7 +144,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_oneFieldSpecified_success() {
         // desc
-        Index targetIndex = INDEX_THIRD_PERSON;
+        Index targetIndex = INDEX_THIRD_ENTRY;
         String userInput = targetIndex.getOneBased() + TYPE_EXPENDITURE + DESC_LUNCH;
         EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder().withType(VALID_TYPE_EXPENDITURE)
                 .withDescription(VALID_DESC_LUNCH).build();
@@ -181,7 +181,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST_ENTRY;
         String userInput = targetIndex.getOneBased() + TYPE_EXPENDITURE + DATE_LUNCH + AMT_LUNCH
                 + TAG_DESC_MEAL + TYPE_EXPENDITURE + DATE_LUNCH + AMT_LUNCH + TAG_DESC_MEAL
                 + TYPE_EXPENDITURE + DATE_DINNER + AMT_DINNER + TAG_DESC_PERSONAL;
@@ -199,7 +199,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidValueFollowedByValidValue_success() {
         // no other valid values specified
-        Index targetIndex = INDEX_FIRST_PERSON;
+        Index targetIndex = INDEX_FIRST_ENTRY;
         String userInput = targetIndex.getOneBased() + INVALID_TYPE + TYPE_EXPENDITURE + DESC_DINNER;
         EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder()
                 .withType(VALID_TYPE_EXPENDITURE)

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
 
 import org.junit.jupiter.api.Test;
 
@@ -46,10 +46,10 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("1"));
+        assertEquals(INDEX_FIRST_ENTRY, ParserUtil.parseIndex("1"));
 
         // Leading and trailing whitespaces
-        assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+        assertEquals(INDEX_FIRST_ENTRY, ParserUtil.parseIndex("  1  "));
     }
 
 

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -6,7 +6,7 @@ import seedu.address.commons.core.index.Index;
  * A utility class containing a list of {@code Index} objects to be used in tests.
  */
 public class TypicalIndexes {
-    public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
-    public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
-    public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST_ENTRY = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_ENTRY = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_ENTRY = Index.fromOneBased(3);
 }


### PR DESCRIPTION
4620d12603cc9b720245b15a135a25abd34b9f89: Check for duplication of edited entry for both income and expenditure, instead of just expenditure.

d1011f335b2f8e3e8ffce4b7dfed52ff5fd4455e: Clean up related test cases for `EditCommand`, removing traces of `person`.