### PR TITLE
Fix amount validation bug

### DIFF
--- a/src/main/java/seedu/address/model/entry/Amount.java
+++ b/src/main/java/seedu/address/model/entry/Amount.java
@@ -5,6 +5,8 @@ import static java.lang.Double.parseDouble;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.text.DecimalFormat;
+
 /**
  * Represents an Entry's amount in the penny wise application.
  * Guarantees: immutable; is valid as declared in {@link #isValidAmount(String)}
@@ -13,7 +15,9 @@ public class Amount {
 
     public static final String MESSAGE_CONSTRAINTS = "Expense amount should only contain positive numbers, "
                     + "and it should be formatted to accept 2 decimal places";
-    public static final String VALIDATION_REGEX = "^\\s*(?=.*[1-9])\\d*(?:\\.\\d{1,2})?\\s*$";
+    public static final String VALIDATION_REGEX = "^\\s*(?=.*[1-9])\\d*\\.\\d{2}\\s*$";
+    private static final DecimalFormat AMOUNT_FORMAT = new DecimalFormat("0.00");
+
     private final double amount;
     private final String amountString;
 
@@ -41,7 +45,8 @@ public class Amount {
     }
 
     public static Amount add(Amount amount1, Amount amount2) {
-        return new Amount(String.valueOf(amount1.getValue() + amount2.getValue()));
+        double amount = amount1.getValue() + amount2.getValue();
+        return new Amount(AMOUNT_FORMAT.format(amount));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/entry/Amount.java
+++ b/src/main/java/seedu/address/model/entry/Amount.java
@@ -44,6 +44,16 @@ public class Amount {
         return amount;
     }
 
+    /**
+     * Adds the value in the two specified {@code Amount} and returns a new {@code Amount}
+     * that contains a value equivalent to the sum. The addition respects the standard
+     * addition operator and its properties, such as commutativity, associativity, identity
+     * and distributivity.
+     *
+     * @param amount1 An {@code Amount} containing the value to be added
+     * @param amount2 An {@code Amount} containing the value to be added
+     * @return An {@code Amount} containing the value of the sum of the two specified {@Amount}.
+     */
     public static Amount add(Amount amount1, Amount amount2) {
         double amount = amount1.getValue() + amount2.getValue();
         return new Amount(AMOUNT_FORMAT.format(amount));

--- a/src/test/java/seedu/address/model/entry/AmountTest.java
+++ b/src/test/java/seedu/address/model/entry/AmountTest.java
@@ -22,10 +22,15 @@ public class AmountTest {
 
     @Test
     public void add_validAmounts_success() {
-        Amount amount1 = new seedu.address.model.entry.Amount("1.00");
-        Amount amount2 = new seedu.address.model.entry.Amount("2.00");
+        Amount amount1a = new seedu.address.model.entry.Amount("1.00");
+        Amount amount2a = new seedu.address.model.entry.Amount("2.00");
 
-        assertEquals(new seedu.address.model.entry.Amount("3.00"), Amount.add(amount1, amount2));
+        assertEquals(new seedu.address.model.entry.Amount("3.00"), Amount.add(amount1a, amount2a));
+
+        Amount amount1b = new seedu.address.model.entry.Amount("1.29");
+        Amount amount2b = new seedu.address.model.entry.Amount("2.33");
+
+        assertEquals(new seedu.address.model.entry.Amount("3.62"), Amount.add(amount1b, amount2b));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/entry/AmountTest.java
+++ b/src/test/java/seedu/address/model/entry/AmountTest.java
@@ -30,16 +30,34 @@ public class AmountTest {
 
     @Test
     public void isValidAmount() {
-        // null amount
+        // EP: null
         assertThrows(NullPointerException.class, () -> Amount.isValidAmount(null));
 
-        // invalid amount
-        assertFalse(Amount.isValidAmount(""));
+        // EP: empty string
+        assertFalse(Amount.isValidAmount("")); // Boundary value
         assertFalse(Amount.isValidAmount("  "));
 
-        // valid amount
-        String validAmount = "3.22";
-        assertTrue(Amount.isValidAmount(validAmount));
+        // EP: not a number
+        assertFalse(Amount.isValidAmount("abc"));
+        assertFalse(Amount.isValidAmount("aaa"));
 
+        // EP: negative numbers
+        assertFalse(Amount.isValidAmount("-1"));
+        assertFalse(Amount.isValidAmount("-1.11"));
+
+        // EP: numbers with white space
+        assertFalse(Amount.isValidAmount("3. 22"));
+
+        // EP: positive numbers
+        assertTrue(Amount.isValidAmount("3.22"));
+        assertTrue(Amount.isValidAmount("30.22"));
+        assertTrue(Amount.isValidAmount("30000.22"));
+        assertTrue(Amount.isValidAmount(" 3.22")); // leading white space
+        assertTrue(Amount.isValidAmount("3.22 ")); // trailing white space
+        assertTrue(Amount.isValidAmount(" 3.22 "));
+
+        assertFalse(Amount.isValidAmount("3")); // Zero decimal place
+        assertFalse(Amount.isValidAmount("3.1")); // One decimal place
+        assertFalse(Amount.isValidAmount("3.333")); // Three decimal place
     }
 }

--- a/src/test/java/seedu/address/model/entry/ExpenditureTest.java
+++ b/src/test/java/seedu/address/model/entry/ExpenditureTest.java
@@ -15,13 +15,6 @@ import seedu.address.testutil.ExpenditureBuilder;
 
 
 public class ExpenditureTest {
-
-    // @Test
-    // public void asObservableList_modifyList_throwsUnsupportedOperationException() {
-    //     Entry expenditure = new ExpenditureBuilder().build();
-    //     assertThrows(UnsupportedOperationException.class, () -> expenditure.getTag());
-    // }
-
     @Test
     public void isSameExpenditure() {
         // same object -> returns True
@@ -33,7 +26,6 @@ public class ExpenditureTest {
 
     @Test
     public void equals() {
-
         //same values -> returns true
         Entry lunchCopy = new ExpenditureBuilder(LUNCH).build();
         assertTrue(LUNCH.equals(lunchCopy));
@@ -65,7 +57,5 @@ public class ExpenditureTest {
         // different tags -> return false
         editedEntry = new ExpenditureBuilder(LUNCH).withTag(VALID_TAG_MOVIE).build();
         assertFalse(LUNCH.equals(editedEntry));
-
-
     }
 }


### PR DESCRIPTION
# Problem

https://regexr.com/70vsq

The previous Regex was not strict in enforcing that the number of digits in the decimal place must be exactly 2.

![Screenshot 2022-10-26 at 9 31 53 PM](https://user-images.githubusercontent.com/21200681/198039292-2f73524d-3b50-4263-a326-57c983284e52.png)

# Causes

Should only match exactly 2 decimal digits.

![Screenshot 2022-10-26 at 9 32 48 PM](https://user-images.githubusercontent.com/21200681/198039524-e91e26ee-a099-4810-a631-cfc4e8f60dd6.png)

I believe the quantifier is not needed because the check for the digits is compulsory.

![Screenshot 2022-10-26 at 9 33 25 PM](https://user-images.githubusercontent.com/21200681/198039704-9f6ccc9a-cd59-4f6b-b1e6-cb13da89959e.png)

# Test

I added more equivalence partitioning test cases, referencing details from https://github.com/se-edu/addressbook-level3/blob/master/src/test/java/seedu/address/commons/util/StringUtilTest.java.

