### PR TITLE
fix bug in description equals function

### DIFF
--- a/src/main/java/seedu/pennywise/model/entry/Description.java
+++ b/src/main/java/seedu/pennywise/model/entry/Description.java
@@ -47,7 +47,7 @@ public class Description {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Description // instanceof handles nulls
-                && fullDescription.equals(((Description) other).fullDescription)); // state check
+                && fullDescription.equalsIgnoreCase(((Description) other).fullDescription)); // state check
     }
 
     @Override


### PR DESCRIPTION
closes #133 
Changes equals to equalsIgnoreCase

duck rice and DUCK RICE will now be equal