### PR TITLE
Fix direct copying of string value

### DIFF
--- a/src/main/java/seedu/pennywise/model/entry/Amount.java
+++ b/src/main/java/seedu/pennywise/model/entry/Amount.java
@@ -28,7 +28,7 @@ public class Amount {
         requireNonNull(amount);
         checkArgument(isValidAmount(amount), MESSAGE_CONSTRAINTS);
         this.amount = parseDouble(amount);
-        this.amountString = amount;
+        this.amountString = df.format(this.amount);
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/AY2223S1-CS2103T-W17-2/tp/issues/118

# Issue

The `amountString` stores the `amount` input given directly by the user, which may contain trailing zeros etc. The `amountString` is then used to format the output.

# To Test

1. Enter `add t/e d/Hello a/000007 da/05-02-2022 c/Food` in the command box.
2. The amount display should be formatted to the correct string.
![Screenshot 2022-11-01 at 10 07 09 PM](https://user-images.githubusercontent.com/21200681/199252738-15084760-7f15-4a1d-8f00-d3556174c65e.png)
