### PR TITLE
Fix amount overflow

### DIFF
--- a/src/main/java/seedu/pennywise/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/pennywise/logic/parser/ParserUtil.java
@@ -96,6 +96,9 @@ public class ParserUtil {
         if (!Amount.isValidAmount(amount)) {
             throw new ParseException(Amount.MESSAGE_CONSTRAINTS);
         }
+        if (!Amount.isAmountWithinLimits(amount)) {
+            throw new ParseException(Amount.MESSAGE_TOO_LARGE);
+        }
         return new Amount(trimmedAmount);
     }
 

--- a/src/main/java/seedu/pennywise/model/entry/Amount.java
+++ b/src/main/java/seedu/pennywise/model/entry/Amount.java
@@ -8,34 +8,55 @@ import java.text.DecimalFormat;
 
 /**
  * Represents an {@code Entry}'s amount in the PennyWise application.
- * Guarantees: immutable; is valid as declared in {@link #isValidAmount(String)}
+ * Guarantees: immutable; is valid as declared in {@link #isValidAmount(String)} and
+ * {@link #isAmountWithinLimits(String)}
  */
 public class Amount {
-
-    public static final String MESSAGE_CONSTRAINTS = "Expense amount should only contain positive numbers, "
+    public static final String MESSAGE_CONSTRAINTS = "Amount should only contain positive numbers, "
         + "and it should be formatted to accept 2 decimal places";
+    public static final String MESSAGE_TOO_LARGE = "Amount value is too large and should be smaller than 1 000 000";
+
     public static final String VALIDATION_REGEX = "^\\s*(?=.*[1-9])\\d*(?:\\.\\d{1,2})?\\s*$";
     private static final DecimalFormat df = new DecimalFormat("0.00");
+
+    private static final Double AMOUNT_LIMIT = 1000000.00;
+
     private final double amount;
     private final String amountString;
 
     /**
      * Constructs a {@code Amount}.
      *
-     * @param amount A valid expense amount.
+     * @param amount A valid amount.
      */
     public Amount(String amount) {
         requireNonNull(amount);
         checkArgument(isValidAmount(amount), MESSAGE_CONSTRAINTS);
+        checkArgument(isAmountWithinLimits(amount), MESSAGE_TOO_LARGE);
         this.amount = parseDouble(amount);
         this.amountString = df.format(this.amount);
     }
 
     /**
-     * Returns true if a given string is a valid expense amount.
+     * Returns true if a given string {@code test} is a valid amount format.
      */
     public static boolean isValidAmount(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if a given string {@code test} is within computable limits.
+     */
+    public static boolean isAmountWithinLimits(String test) {
+        try {
+            double amount = parseDouble(test);
+            if (Double.isInfinite(amount) || Double.compare(amount, AMOUNT_LIMIT) > 0) {
+                return false;
+            }
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     public double getValue() {

--- a/src/main/java/seedu/pennywise/storage/JsonAdaptedEntry.java
+++ b/src/main/java/seedu/pennywise/storage/JsonAdaptedEntry.java
@@ -61,6 +61,9 @@ public abstract class JsonAdaptedEntry {
         if (!Amount.isValidAmount(amount)) {
             throw new IllegalValueException(Amount.MESSAGE_CONSTRAINTS);
         }
+        if (!Amount.isAmountWithinLimits(amount)) {
+            throw new IllegalValueException(Amount.MESSAGE_TOO_LARGE);
+        }
         if (date == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName()));
         }

--- a/src/test/java/seedu/pennywise/model/entry/AmountTest.java
+++ b/src/test/java/seedu/pennywise/model/entry/AmountTest.java
@@ -22,7 +22,9 @@ public class AmountTest {
         assertThrows(IllegalArgumentException.class, () -> new Amount(" "));
         assertThrows(IllegalArgumentException.class, () -> new Amount("123.1212"));
         assertThrows(IllegalArgumentException.class, () -> new Amount("abc"));
-        assertThrows(IllegalArgumentException.class, () -> new Amount("99999999999999999999999999999999999999999999999999999999999999"));
+        assertThrows(IllegalArgumentException.class, () -> new Amount(
+                "99999999999999999999999999999999999999999999999999999999999999"
+        ));
     }
 
     @Test

--- a/src/test/java/seedu/pennywise/model/entry/AmountTest.java
+++ b/src/test/java/seedu/pennywise/model/entry/AmountTest.java
@@ -19,8 +19,10 @@ public class AmountTest {
 
     @Test
     public void constructor_invalidAmount_throwsIllegalArgumentException() {
-        String invalidAmount = "";
-        assertThrows(IllegalArgumentException.class, () -> new Amount(invalidAmount));
+        assertThrows(IllegalArgumentException.class, () -> new Amount(" "));
+        assertThrows(IllegalArgumentException.class, () -> new Amount("123.1212"));
+        assertThrows(IllegalArgumentException.class, () -> new Amount("abc"));
+        assertThrows(IllegalArgumentException.class, () -> new Amount("99999999999999999999999999999999999999999999999999999999999999"));
     }
 
     @Test
@@ -44,6 +46,24 @@ public class AmountTest {
         String validAmount = "3.22";
         assertTrue(Amount.isValidAmount(validAmount));
 
+    }
+
+    @Test
+    public void isAmountWithinLimits() {
+        // null amount
+        assertThrows(NullPointerException.class, () -> Amount.isAmountWithinLimits(null));
+
+        // invalid amount
+        assertFalse(Amount.isAmountWithinLimits("abc"));
+        assertFalse(Amount.isAmountWithinLimits("  "));
+
+        // valid amount
+        assertTrue(Amount.isAmountWithinLimits("1000000.00")); // boundary value
+        assertTrue(Amount.isAmountWithinLimits("999999.99")); // boundary value
+        assertFalse(Amount.isAmountWithinLimits("1000000.01")); // boundary value
+        assertFalse(Amount.isAmountWithinLimits("99999999999999999999999999999999999999999999999999999999999999"));
+        assertTrue(Amount.isAmountWithinLimits("333333.22"));
+        assertTrue(Amount.isAmountWithinLimits("0"));
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/AY2223S1-CS2103T-W17-2/tp/issues/127

# Bug

Currently, entering a very large number as an amount in the application causes the application to crash. You can test it with:

```
add t/e d/Lunch da/04-10-2022 c/Food a/999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
```

# What changed

Handled overflow by restricting the amount limits